### PR TITLE
Refactor: Add get_report Methods

### DIFF
--- a/src/kaggle_housing_prices/process/feature_engineering.py
+++ b/src/kaggle_housing_prices/process/feature_engineering.py
@@ -55,7 +55,7 @@ class BaseFeatureEngineer(ABC):
         """Get feature engineering report.
 
         Args:
-            X_prime (pd.DataFrame): Engineered features
+            X_prime (pd.DataFrame): Engineered features.
             y (npt.NDArray[np.float32], None], optional): Observed prices. If
                 specified, additional, label-dependent metrics are returned.
                 Defaults to None.
@@ -113,7 +113,10 @@ class BayesianEncodingFeatureEngineer(BaseFeatureEngineer):
         return X_prime
 
     def get_report(
-        self, X_prime: pd.DataFrame, y: Union[npt.NDArray[np.float32], None], **kwargs
+        self,
+        X_prime: pd.DataFrame,
+        y: Union[npt.NDArray[np.float32], None] = None,
+        **kwargs,
     ) -> Dict[str, Any]:
         # Get engineering report, with more metrics, if y is specified
         independent_report = self._get_independent_report(X_prime)

--- a/test/kaggle_housing_prices_test.py
+++ b/test/kaggle_housing_prices_test.py
@@ -149,7 +149,7 @@ class TestFeatureEngineering(CommonTestFixtures):
         assert actual.to_numpy().dtype == np.float32
 
     @pytest.mark.parametrize("fit_instance", FEATURE_ENGINEERS_TO_TEST, indirect=True)
-    def get_report_retruns_dict_of_artifacts_test(
+    def get_report_returns_dict_of_artifacts_test(
         self, fit_instance, mock_engineered_data
     ):
         """Assert, that get_report returns returns the expected type."""
@@ -165,7 +165,7 @@ class TestRegressor(CommonTestFixtures):
 
     @pytest.fixture(scope="class")
     def fit_test_instance(self, request, mock_engineered_data):
-        """INstantiate regressor and fit."""
+        """Instantiate regressor and fit."""
         fit_instance = request.param().fit(
             mock_engineered_data[0], mock_engineered_data[1]
         )
@@ -178,24 +178,22 @@ class TestRegressor(CommonTestFixtures):
         assert isinstance(fit_test_instance, BaseRegressor)
 
     @pytest.mark.parametrize("fit_test_instance", REGRESSORS_TO_TEST, indirect=True)
-    def predict_with_labels_returns_tuple_of_prediction_and_report_test(
-        self, fit_test_instance, mock_engineered_data
-    ):
+    def prediction_returns_array_test(self, fit_test_instance, mock_engineered_data):
         """Assert, that passing labels to predict will result in a prediction and report."""
-        actual, _ = fit_test_instance.predict(
+        actual = fit_test_instance.predict(
             mock_engineered_data[0], mock_engineered_data[1]
         )
 
         assert isinstance(actual, np.ndarray)
 
     @pytest.mark.parametrize("fit_test_instance", REGRESSORS_TO_TEST, indirect=True)
-    def predict_without_labels_returns_tuple_of_prediction_and_report_test(
-        self, fit_test_instance, mock_engineered_data
+    def get_report_returns_dict_of_artifacts_test(
+        self, fit_test_instance, mock_engineered_data, mock_prices
     ):
-        """Assert, that not passing labels to predict will result in a prediction and report."""
-        actual, _ = fit_test_instance.predict(mock_engineered_data[0])
+        """Assert, that get_report returns returns the expected type."""
+        actual = fit_test_instance.get_report(mock_engineered_data[1], mock_prices)
 
-        assert isinstance(actual, np.ndarray)
+        check_type("report", actual, Dict[str, Any])
 
 
 class TestPricePredictionModel(CommonTestFixtures):

--- a/test/kaggle_housing_prices_test.py
+++ b/test/kaggle_housing_prices_test.py
@@ -1,11 +1,12 @@
 """Test module for feature engineering."""
 
-from typing import List
+from typing import Any, Dict, List
 
 import lorem
 import numpy as np
 import pandas as pd
 import pytest
+from typeguard import check_type
 from kaggle_housing_prices.process.feature_engineering import (
     BaseFeatureEngineer,
     BayesianEncodingFeatureEngineer,
@@ -142,11 +143,21 @@ class TestFeatureEngineering(CommonTestFixtures):
     @pytest.mark.parametrize("fit_instance", FEATURE_ENGINEERS_TO_TEST, indirect=True)
     def transform_returns_pandas_df_test(self, fit_instance, mock_features):
         """Assert, that transform returns a numpy array."""
-        actual, report = fit_instance.transform(mock_features)
+        actual = fit_instance.transform(mock_features)
 
         assert isinstance(actual, pd.DataFrame)
         assert actual.to_numpy().dtype == np.float32
-        assert isinstance(report, dict)
+
+    @pytest.mark.parametrize("fit_instance", FEATURE_ENGINEERS_TO_TEST, indirect=True)
+    def get_report_retruns_dict_of_artifacts_test(
+        self, fit_instance, mock_engineered_data
+    ):
+        """Assert, that get_report returns returns the expected type."""
+        actual = fit_instance.get_report(
+            mock_engineered_data[0], mock_engineered_data[1]
+        )
+
+        check_type("report", actual, Dict[str, Any])
 
 
 class TestRegressor(CommonTestFixtures):

--- a/test/kaggle_housing_prices_test.py
+++ b/test/kaggle_housing_prices_test.py
@@ -203,10 +203,11 @@ class TestPricePredictionModel(CommonTestFixtures):
     def fit_test_instance(
         self, request, mock_features_with_missing_values, mock_prices
     ):
-        """Fit model to test to mock_data."""
+        """Fit model to test to mock_data and predict."""
         instance = request.param(
             Preprocessor(), BayesianEncodingFeatureEngineer(), SklearnRegressor()
         ).fit(mock_features_with_missing_values, mock_prices)
+        _ = instance.predict(mock_features_with_missing_values)
 
         return instance
 
@@ -221,13 +222,12 @@ class TestPricePredictionModel(CommonTestFixtures):
     ):
         """Assert, that a call to predict returns a tuple of a prediction and a
         prediction report, if labels are passed."""
-        actual, report = fit_test_instance.predict(
+        actual = fit_test_instance.predict(
             mock_features_with_missing_values, mock_prices
         )
 
         assert isinstance(actual, np.ndarray)
         assert actual.shape == (self.NUM_SAMPLES,)
-        assert isinstance(report, dict)
 
     @pytest.mark.parametrize("fit_test_instance", MODELS_TO_TEST, indirect=True)
     def predict_without_labels_returns_tuple_of_prediction_and_report_test(
@@ -235,8 +235,14 @@ class TestPricePredictionModel(CommonTestFixtures):
     ):
         """Assert, that a call to predict returns a tuple of a prediction and a
         prediction report, if no labels are passed."""
-        actual, report = fit_test_instance.predict(mock_features_with_missing_values)
+        actual = fit_test_instance.predict(mock_features_with_missing_values)
 
         assert isinstance(actual, np.ndarray)
         assert actual.shape == (self.NUM_SAMPLES,)
-        assert isinstance(report, dict)
+
+    @pytest.mark.parametrize("fit_test_instance", MODELS_TO_TEST, indirect=True)
+    def get_report_returns_dict_test(self, fit_test_instance, mock_prices):
+        """Assert, that get_report returns a dictionary."""
+        actual = fit_test_instance.get_report(mock_prices)
+
+        check_type("report", actual, Dict[str, Any])


### PR DESCRIPTION
## Refactoring
- [Add get_report method to Feature Engineer](https://github.com/MarcoCaglia/kaggle-housing-prices/commit/d7da199c9cd1fac59764baa3c0ddbf85a5bfcd52)
- [Add get_report method to regressor](https://github.com/MarcoCaglia/kaggle-housing-prices/commit/cbe8a9bd083ae1cbccd234388528d45ebe83e070)
- [Add get_report method to price model](https://github.com/MarcoCaglia/kaggle-housing-prices/commit/216094b0c341f92b5c43e32161d4cd578611780c)